### PR TITLE
Remove encrypted-tbn0.gstatic.com

### DIFF
--- a/SpotifyBlocklist.txt
+++ b/SpotifyBlocklist.txt
@@ -1292,7 +1292,6 @@ eip-ntt.audio-ak.spotify.com.akahost.net
 eip-onnet.audio-ak.spotify.com.akahost.net
 eip-tata.audio-ak.spotify.com.akahost.net
 ejs.moatads.com
-encrypted-tbn0.gstatic.com
 eng.admob.com
 engineering.intercom.io
 eu-gmtdmp.gd1.mookie1.com

--- a/hosts
+++ b/hosts
@@ -1370,7 +1370,6 @@
 0.0.0.0 eip-onnet.audio-ak.spotify.com.akahost.net
 0.0.0.0 eip-tata.audio-ak.spotify.com.akahost.net
 0.0.0.0 ejs.moatads.com
-0.0.0.0 encrypted-tbn0.gstatic.com
 0.0.0.0 eng.admob.com
 0.0.0.0 engineering.intercom.io
 0.0.0.0 eu-gmtdmp.gd1.mookie1.com


### PR DESCRIPTION
Hello! I had a complaint that someone on my network couldn't use Google Image Search, that it would only return the top three images - the rest rendered as coloured squares.

Whitelisting this domain resolved the issue. Cheers!